### PR TITLE
Feature/common js export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-dist
+dist*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ React hooks library
 
 ## Documentation
 
+### useBeforeMount
+A hook that runs before mount and is suitable for SSR.
 ```js
 useBeforeMount(() =>
-    console.log('Runs only once before component mounts')
+    console.log('Runs only once before component mounts. Works on the server!')
 )
 ```
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,10 +11,11 @@ module.exports = api => {
                         'not ie <= 11',
                         'not ie_mob <= 11',
                     ],
+                    esmodules: true
                 },
                 useBuiltIns: 'entry',
                 corejs: 3,
-                modules: false,
+                modules: process.env.CJS ? 'commonjs' : false,
             },
         ],
         [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@24hr/react-hooks",
-  "version": "0.0.17",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@24hr/react-hooks",
-  "version": "0.0.19",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@24hr/react-hooks",
-    "version": "0.0.19",
+    "version": "1.0.0",
     "description": "react hooks",
     "main": "dist-cjs/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -2,18 +2,22 @@
     "name": "@24hr/react-hooks",
     "version": "0.0.19",
     "description": "react hooks",
-    "main": "dist/index.js",
+    "main": "dist-cjs/index.js",
     "files": [
-        "dist",
+        "dist-es",
+        "dist-cjs",
         "package.json"
     ],
     "repository": "https://github.com/24hr-malmo/react-hooks",
-    "module": "dist",
+    "module": "dist-es/index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "build": "babel src --out-dir dist"
+        "build:es": "babel src --out-dir dist-es",
+        "build:cjs": "CJS=true babel src --out-dir dist-cjs",
+        "build": "npm run build:es && npm run build:cjs",
+        "watch": "babel src --out-dir dist-modern --watch"
     },
-    "author": "Tina Håkansson <tina.hakansson@24hr.se>",
+    "author": "Tina Håkansson <tina.hakansson@24hr.se>, Marcus Thelin <marcus.thelin@24hr.se>",
     "license": "MIT",
     "devDependencies": {
         "@babel/cli": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "build:es": "babel src --out-dir dist-es",
         "build:cjs": "CJS=true babel src --out-dir dist-cjs",
         "build": "npm run build:es && npm run build:cjs",
-        "watch": "babel src --out-dir dist-modern --watch"
+        "watch": "babel src --out-dir dist-es --watch"
     },
     "author": "Tina Håkansson <tina.hakansson@24hr.se>, Marcus Thelin <marcus.thelin@24hr.se>",
     "license": "MIT",


### PR DESCRIPTION
Babel will now output an esmodules and a commonjs version. This will fix the issue were the SSR broke.

This preserves the tree shakability! 

Closes #5 